### PR TITLE
fix: supply subnetwork to `google_compute_address`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -38,6 +38,7 @@ resource "google_compute_address" "default" {
   region       = var.region
   network_tier = var.attach_public_ip == false ? null : var.network_tier
   address_type = var.attach_public_ip == false ? "INTERNAL" : "EXTERNAL"
+  subnetwork   = var.subnetwork
 }
 
 // Use an external disk so that it can be remounted on another instance.


### PR DESCRIPTION
`terraform apply` fails, if you try to use an internal ip address and do not have the default network in your GCP project. Supplying the `subnetwork` field to `google_compute_address` will fix that.